### PR TITLE
Shell script to merge registered device keys with binary

### DIFF
--- a/merge/nrf52dk.json
+++ b/merge/nrf52dk.json
@@ -1,0 +1,4 @@
+{
+	"key_offset": "0x29606",
+	"utc_offset": "0x291a0"
+}

--- a/provision_merge.sh
+++ b/provision_merge.sh
@@ -78,6 +78,9 @@ case "$BOARD_ID" in
     nrf21540dk)
         JLINK_DEVICE="nRF52840_xxAA"
         ;;
+    nrf52dk)
+        JLINK_DEVICE="nRF52832_xxAA"
+        ;;
     *)
         echo "[ERROR] Unsupported board ID: $BOARD_ID" >&2
         echo "[ERROR] Supported boards: xg24_ek2703a, nrf21540dk" >&2
@@ -86,8 +89,8 @@ case "$BOARD_ID" in
 esac
 
 # Set firmware filename based on board ID
-FIRMWARE_BIN="${BOARD_ID}.bin"
-MERGED_FIRMWARE_BIN="${BOARD_ID}_merged.bin"
+FIRMWARE_BIN="${BOARD_ID}.elf"
+MERGED_FIRMWARE_BIN="${BOARD_ID}_merged.elf"
 
 echo "[INFO] Starting device provisioning..."
 echo "[INFO] Device ID: $DEVICE_ID"
@@ -156,51 +159,72 @@ if [[ ! -f "$FIRMWARE_BIN" ]]; then
     echo "[INFO] Binary firmware downloaded successfully"
 fi
 
+# Copy original file to output
+cp "$FIRMWARE_BIN" "$MERGED_FIRMWARE_BIN"
+echo "[SUCCESS] Created merged binary file: $MERGED_FIRMWARE_BIN"
+
 # =============================================================================
 # Merge Key into Firmware
 # =============================================================================
 echo "[INFO] Merging key into firmware at offset $KEY_OFFSET..."
 
-# Function to convert base64 key to binary bytes
-base64_to_binary() {
-    local base64_key="$1"
-    
-    # Decode base64 to binary using system command
-    echo -n "$base64_key" | base64 -d
-}
-
 # Convert offset to decimal
-offset_decimal=$((KEY_OFFSET))
+offset_decimal_key=$((KEY_OFFSET))
 
 # Convert key to binary bytes
-key_binary=$(base64_to_binary "$KEY")
+key_binary=$(printf '%s' "$KEY" | base64 -D)
 
 # Get file size
 file_size=$(stat -f%z "$FIRMWARE_BIN" 2>/dev/null || stat -c%s "$FIRMWARE_BIN" 2>/dev/null)
 
 # Check if offset is within file bounds
-if [[ $offset_decimal -ge $file_size ]]; then
+if [[ $offset_decimal_key -ge $file_size ]]; then
     echo "[ERROR] Key offset $KEY_OFFSET is beyond file size $file_size" >&2
     exit 1
 fi
 
 # Check if key fits at offset
-if [[ $((offset_decimal + KEY_LENGTH)) -gt $file_size ]]; then
+if [[ $((offset_decimal_key + KEY_LENGTH)) -gt $file_size ]]; then
     echo "[ERROR] Key would extend beyond file size" >&2
     exit 1
 fi
 
-# Copy original file to output
-cp "$FIRMWARE_BIN" "$MERGED_FIRMWARE_BIN"
-
 # Write key to output file at specified offset
-echo "[INFO] Writing key to binary file at offset $offset_decimal"
-if ! printf "%s" "$key_binary" | dd of="$MERGED_FIRMWARE_BIN" bs=1 seek=$offset_decimal conv=notrunc 2>/dev/null; then
+echo "[INFO] Writing key to binary file at offset $offset_decimal_key"
+if ! printf "%s" "$key_binary" | dd of="$MERGED_FIRMWARE_BIN" bs=1 seek=$offset_decimal_key conv=notrunc 2>/dev/null; then
     echo "[ERROR] Failed to write key to binary file" >&2
     exit 1
 fi
 
-echo "[SUCCESS] Created merged binary firmware: $MERGED_FIRMWARE_BIN"
+echo "[SUCCESS] Merged key into binary firmware"
+
+# =============================================================================
+# Merge UTC time into Firmware
+# =============================================================================
+echo "[INFO] Merging UTC time into firmware at offset $UTC_OFFSET..."
+
+# Convert offset to decimal
+offset_decimal_utc=$((UTC_OFFSET))
+
+# Get the UTC time in milliseconds (approximately)
+utc_time=$(($(date +%s)*1000))
+
+# Check if UTC fits at offset
+if [[ $((offset_decimal_utc + 8)) -gt $file_size ]]; then
+    echo "[ERROR] UTC time would extend beyond file size" >&2
+    exit 1
+fi
+
+# Write the UTC time to the output file after retrieving the current unix epoch. Reverse endianness.
+if ! printf '%016x' "$utc_time" | \
+    sed -E 's/(..)(..)(..)(..)(..)(..)(..)(..)/\8\7\6\5\4\3\2\1/' | \
+    xxd -r -p | \
+    dd of="$MERGED_FIRMWARE_BIN" bs=1 seek=$offset_decimal_utc conv=notrunc 2>/dev/null; then
+    echo "[ERROR] Failed to write UTC to binary file" >&2
+    exit 1
+fi
+
+echo "[SUCCESS] Merged UTC time into binary firmware"
 
 # =============================================================================
 # Flash Merged Firmware


### PR DESCRIPTION
Adds support for the provision_merge.sh script to:
1. Pull appropriate binary + metadata
2. Provision a key on the Hubble backend
3. Merge the provisioned key + UTC time with the binary
4. Flash the device