### PR TITLE
Add CLI parameters for device name and hex output path

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyhubbledemo"
-version = "0.0.5"
+version = "0.0.6"
 requires-python = ">=3.9"
 authors = [
   { name="Paul Buckley", email="paul@hubble.com" },

--- a/python/src/hubbledemo/cli.py
+++ b/python/src/hubbledemo/cli.py
@@ -111,11 +111,12 @@ def flash(board: str, name: str = None, file: str = None, org_id: str = None, to
     click.secho(f"\tDevice ID:  {device.id}")
     click.secho(f"\tDevice Key: {device.key}")
 
+    # Generate device name if not provided
+    device_name = name if name else petname.generate(words=3)
     if not name:
-        name = petname.generate(words=3)
-        click.secho(f'[INFO] No name supplied. Naming device "{name}"')
+        click.secho(f'[INFO] No name supplied. Naming device "{device_name}"')
     click.secho("[INFO] Setting device name... ", nl=False)
-    org.set_device_name(device_id=device.id, name=name)
+    org.set_device_name(device_id=device.id, name=device_name)
     click.secho("[SUCCESS]")
 
     click.secho(f"[INFO] Retrieving binary for {board}... ", nl=False)
@@ -140,7 +141,9 @@ def flash(board: str, name: str = None, file: str = None, org_id: str = None, to
         if file:
             output_path = file
         else:
-            output_path = f"{name}.hex"
+            # Use the provided name or the device name for the hex filename
+            hex_filename = name if name else device_name
+            output_path = f"{hex_filename}.hex"
         
         hubbledemo.convert_elf_to_hex(buf=buf, output_path=output_path)
         click.secho("[SUCCESS]")

--- a/python/src/hubbledemo/cli.py
+++ b/python/src/hubbledemo/cli.py
@@ -48,6 +48,22 @@ def probe() -> None:
 @cli.command("flash")
 @click.argument("board", type=str)
 @click.option(
+    "--name",
+    "-n",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Device name (if not provided, a random name will be generated)",
+)
+@click.option(
+    "--file",
+    "-f",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Output path for hex file (only used with generate-hex method)",
+)
+@click.option(
     "--org-id",
     "-o",
     type=str,
@@ -63,7 +79,7 @@ def probe() -> None:
     show_default=False,  # show default in --help
     help="Token (if not using HUBBLE_API_TOKEN env var)",
 )
-def flash(board: str, name: str = None, org_id: str = None, token: str = None) -> None:
+def flash(board: str, name: str = None, file: str = None, org_id: str = None, token: str = None) -> None:
     click.secho("[INFO] Getting metadata... ", nl=False)
     metadata = hubbledemo.fetch_metadata()
     click.secho("[SUCCESS]")
@@ -119,10 +135,24 @@ def flash(board: str, name: str = None, org_id: str = None, token: str = None) -
         click.secho(f"\n{board} successfully flashed and provisioned!")
     elif metadata[board]["method"] == "generate-hex":
         click.secho("[INFO] Generating hex file... ", nl=False)
-        hubbledemo.convert_elf_to_hex(buf=buf, filename=name)
+        
+        # Determine output path
+        if file:
+            output_path = file
+        else:
+            output_path = f"{name}.hex"
+        
+        hubbledemo.convert_elf_to_hex(buf=buf, output_path=output_path)
         click.secho("[SUCCESS]")
+        
+        # Show absolute path if relative path was used
+        if not os.path.isabs(output_path):
+            full_path = os.path.join(os.getcwd(), output_path)
+        else:
+            full_path = output_path
+        
         click.secho(
-            f"\nHex file written to \"{os.getcwd()}/{name}.hex\"",
+            f"\nHex file written to \"{full_path}\"",
             bg='blue', fg='white')
     else:
         click.secho(

--- a/python/src/hubbledemo/elfmgr.py
+++ b/python/src/hubbledemo/elfmgr.py
@@ -157,7 +157,14 @@ def flash_elf(buf: io.BytesIO, board: str, jlink_device) -> None:
             except OSError:
                 pass
 
-def convert_elf_to_hex(buf: io.BytesIO, filename: str):
+def convert_elf_to_hex(buf: io.BytesIO, output_path: str):
+    """
+    Convert an ELF file to Intel HEX format.
+    
+    Args:
+        buf: io.BytesIO containing the ELF file data
+        output_path: Path where the .hex file will be written (include .hex extension)
+    """
     ih = IntelHex()
 
     buf.seek(0)
@@ -174,6 +181,9 @@ def convert_elf_to_hex(buf: io.BytesIO, filename: str):
         # Store bytes into IntelHex at the proper address
         for offset, b in enumerate(data):
             ih[addr + offset] = b
-        #ih.frombytes(data, offset=addr)
 
-    ih.write_hex_file(str(filename + ".hex"))
+    # Ensure .hex extension if not provided
+    if not output_path.endswith('.hex'):
+        output_path = output_path + '.hex'
+    
+    ih.write_hex_file(output_path)


### PR DESCRIPTION
## Changes

- Add `--name`/`-n` parameter to specify device name (auto-generates if not provided)
- Add `--file`/`-f` parameter to specify hex file output path for generate-hex method
- Update `convert_elf_to_hex` to use `output_path` parameter with proper path handling
- Improve hex file path display to show absolute path
- Bump version to 0.0.6

## Usage Examples

```bash
# With custom name and custom output file
hubbledemo flash lp_em_cc2340r5 -n my-device -f /path/to/firmware.hex -o ORG_ID -t TOKEN

# With custom name and default output location
hubbledemo flash lp_em_cc2340r5 -n my-device -o ORG_ID -t TOKEN

# With auto-generated name
hubbledemo flash lp_em_cc2340r5 -o ORG_ID -t TOKEN
```

## Testing

Tested with TI development boards (lp_em_cc2340r5) to ensure proper hex file generation with custom names and output paths.