### PR TITLE
.github/workflows/HITLtrigger.yml Added workflow to trigger HITL

### DIFF
--- a/.github/workflows/HITLtrigger.yml
+++ b/.github/workflows/HITLtrigger.yml
@@ -1,0 +1,17 @@
+name: HITL Trigger
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  trigger-hitl-endpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger HITL Endpoint Testing
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HITL_ENDPOINT_REPO }}
+          repository: hubblenetwork/hitl-endpoint
+          event-type: tldm-repo-pr
+          client-payload: '{"branch": "${{ github.head_ref || github.ref_name }}"}'


### PR DESCRIPTION
Added HITLtrigger.yml that triggers the workflow on HubbleNetwork/hitl-endpoint. The results will be displayed in the actions tab of that repo.

Signed off by Hunter Patchett, hunter@hubble.com