### PR TITLE
hubble-tldm: HITL Setup

### DIFF
--- a/.github/workflows/HITLtrigger.yml
+++ b/.github/workflows/HITLtrigger.yml
@@ -1,0 +1,17 @@
+name: HITL Trigger
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  trigger-hitl-endpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger HITL Endpoint Testing
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HITL_ENDPOINT_REPO }}
+          repository: hubblenetwork/hitl-endpoint
+          event-type: tldm-repo-pr
+          client-payload: '{"branch": "${{ github.head_ref || github.ref_name }}"}'


### PR DESCRIPTION
Configures the YML workflow to trigger the HITL setup in the hitl-endpoint repo.
Also fixes a bug that prevented the device key from being decoded when overriding
registering that device.

Signed-off-by: hunterhubble <hunter@hubble.com>