### PR TITLE
ci: add workflow to build merge/ firmware ELFs

### DIFF
--- a/.github/scripts/verify-firmware-elf.py
+++ b/.github/scripts/verify-firmware-elf.py
@@ -1,0 +1,53 @@
+"""Pre-publish check that an ELF satisfies the hubbledemo patching contract.
+
+Mirrors the symbol lookup in python/src/hubbledemo/elfmgr.py::_find_symbol —
+if a built ELF passes here, hubbledemo flash will be able to patch it.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+
+REQUIRED_SYMBOLS = ("master_key", "utc_time")
+
+
+def find_symbol(elf: ELFFile, name: str):
+    for sec in elf.iter_sections():
+        if not isinstance(sec, SymbolTableSection):
+            continue
+        for sym in sec.iter_symbols():
+            if sym.name != name:
+                continue
+            shndx = sym["st_shndx"]
+            if shndx == "SHN_UNDEF":
+                raise SystemExit(f"{name}: undefined (imported)")
+            if isinstance(shndx, str):
+                raise SystemExit(f"{name}: special section index {shndx}")
+            target = elf.get_section(shndx)
+            if target is None:
+                raise SystemExit(f"{name}: section index {shndx} not resolvable")
+            if target.name == "bss":
+                continue
+            return sym, target
+    raise SystemExit(f"{name}: not found in .symtab or .dynsym")
+
+
+def main(path: str) -> None:
+    with open(path, "rb") as f:
+        elf = ELFFile(f)
+        for name in REQUIRED_SYMBOLS:
+            sym, sec = find_symbol(elf, name)
+            size = int(sym["st_size"])
+            if size == 0:
+                raise SystemExit(f"{name}: zero size")
+            print(f"  {name}: {size} bytes in {sec.name} @ 0x{sym['st_value']:08x}")
+    print(f"{path}: OK")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: verify-firmware-elf.py <elf>")
+    main(sys.argv[1])

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,0 +1,220 @@
+name: Build firmware ELFs
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Open a PR updating merge/*.elf with the build outputs"
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - "firmware/**"
+      - "merge/md.json"
+      - ".github/workflows/build-firmware.yml"
+      - ".github/scripts/verify-firmware-elf.py"
+
+# Build jobs only need read; only the open-pr job pushes a branch.
+permissions:
+  contents: read
+
+# Cancel superseded PR builds; never cancel manual dispatches (releases).
+concurrency:
+  group: build-firmware-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # 0.17.x breaks the TI fork's libc-hooks.c (CLAUDE.md gotcha) — keep at 0.16.9.
+  ZEPHYR_SDK_VERSION_TI: "0.16.9"
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      zephyr_matrix: ${{ steps.matrix.outputs.zephyr_matrix }}
+      ti_zephyr_matrix: ${{ steps.matrix.outputs.ti_zephyr_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate md.json build fields
+        run: |
+          missing=$(jq -r '
+            to_entries[]
+            | select((.value.workspace // "") == "" or (.value.board_target // "") == "" or (.value.artifact // "") == "")
+            | .key
+          ' merge/md.json)
+          if [ -n "$missing" ]; then
+            echo "::error::merge/md.json entries missing workspace/board_target/artifact: $missing"
+            exit 1
+          fi
+          unknown=$(jq -r '
+            to_entries[]
+            | select((.value.workspace | IN("zephyr", "ti-zephyr")) | not)
+            | "\(.key)=\(.value.workspace)"
+          ' merge/md.json)
+          if [ -n "$unknown" ]; then
+            echo "::error::merge/md.json has entries with unknown workspace (expected zephyr or ti-zephyr): $unknown"
+            exit 1
+          fi
+
+      - name: Build matrices from md.json
+        id: matrix
+        run: |
+          zephyr=$(jq -c '[to_entries[] | select(.value.workspace == "zephyr") | {key, board_target: .value.board_target, artifact: .value.artifact}]' merge/md.json)
+          ti=$(jq -c '[to_entries[] | select(.value.workspace == "ti-zephyr") | {key, board_target: .value.board_target, artifact: .value.artifact}]' merge/md.json)
+          echo "zephyr_matrix=$zephyr" >> "$GITHUB_OUTPUT"
+          echo "ti_zephyr_matrix=$ti" >> "$GITHUB_OUTPUT"
+          echo "Zephyr boards:    $zephyr"
+          echo "TI-Zephyr boards: $ti"
+
+  build-zephyr:
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJSON(needs.setup-matrix.outputs.zephyr_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: zephyrproject-rtos/action-zephyr-setup@v1
+        with:
+          app-path: hubble-demo-app
+          base-path: firmware/zephyr
+          toolchains: arm-zephyr-eabi
+
+      # SiLabs boards (e.g. bg22_ek4108a) require a connectivity-firmware blob
+      # that west blobs treats as opt-in. Fetching unconditionally is a no-op
+      # for boards that don't need it.
+      - name: Fetch HAL blobs
+        working-directory: firmware/zephyr
+        run: west blobs fetch hal_silabs
+
+      - name: Build firmware
+        working-directory: firmware/zephyr
+        env:
+          BOARD_TARGET: ${{ matrix.board.board_target }}
+          ARTIFACT: ${{ matrix.board.artifact }}
+        run: |
+          west build -b "$BOARD_TARGET" -p always hubble-demo-app/app
+          cp build/zephyr/zephyr.elf "$GITHUB_WORKSPACE/$ARTIFACT"
+
+      - name: Verify ELF symbols
+        env:
+          ARTIFACT: ${{ matrix.board.artifact }}
+        run: python .github/scripts/verify-firmware-elf.py "$ARTIFACT"
+
+      - name: Upload ELF
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-elfs-${{ matrix.board.key }}
+          path: ${{ matrix.board.artifact }}
+          if-no-files-found: error
+          retention-days: 14
+
+  build-ti-zephyr:
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJSON(needs.setup-matrix.outputs.ti_zephyr_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # ti-simplelink-crc-tool is invoked by the TI Zephyr build for hex
+      # signing; pull it in before action-zephyr-setup runs west update.
+      - name: Install TI workspace Python requirements
+        run: pip install -r firmware/ti-zephyr/hubble-demo-app/requirements.txt
+
+      - uses: zephyrproject-rtos/action-zephyr-setup@v1
+        with:
+          app-path: hubble-demo-app
+          base-path: firmware/ti-zephyr
+          sdk-version: ${{ env.ZEPHYR_SDK_VERSION_TI }}
+          toolchains: arm-zephyr-eabi
+
+      - name: Build firmware
+        working-directory: firmware/ti-zephyr
+        env:
+          BOARD_TARGET: ${{ matrix.board.board_target }}
+          ARTIFACT: ${{ matrix.board.artifact }}
+        run: |
+          west build -b "$BOARD_TARGET" -p always hubble-demo-app/app
+          cp build/zephyr/zephyr.elf "$GITHUB_WORKSPACE/$ARTIFACT"
+
+      - name: Verify ELF symbols
+        env:
+          ARTIFACT: ${{ matrix.board.artifact }}
+        run: python .github/scripts/verify-firmware-elf.py "$ARTIFACT"
+
+      - name: Upload ELF
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-elfs-${{ matrix.board.key }}
+          path: ${{ matrix.board.artifact }}
+          if-no-files-found: error
+          retention-days: 14
+
+  open-pr:
+    needs: [build-zephyr, build-ti-zephyr]
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all firmware ELFs into merge/
+        uses: actions/download-artifact@v4
+        with:
+          path: merge
+          pattern: firmware-elfs-*
+          merge-multiple: true
+
+      - name: Show pending changes
+        run: |
+          ls -la merge/
+          git status
+
+      - name: Build PR body
+        id: body
+        env:
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "body<<PR_EOF"
+            echo "Automated rebuild of \`merge/*.elf\` from workflow run [#${RUN_ID}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID})."
+            echo
+            echo "**Boards rebuilt:**"
+            jq -r 'to_entries[] | "- `\(.key)` (\(.value.workspace)) → `\(.value.artifact)`"' merge/md.json
+            echo
+            echo "**Reviewer checklist** — merging publishes new firmware to every \`pyhubbledemo\` user:"
+            echo "- [ ] Diff contains only \`merge/*.elf\` changes"
+            echo "- [ ] Spot-check at least one ELF locally with \`hubbledemo flash\` against real hardware"
+            echo "- [ ] Confirm SDK versions in workflow match the intended release toolchain"
+            echo "PR_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: automated/firmware-build-${{ github.run_id }}
+          title: "chore(merge): rebuild firmware ELFs"
+          body: ${{ steps.body.outputs.body }}
+          add-paths: merge/*.elf
+          commit-message: "chore(merge): rebuild firmware ELFs from workflow ${{ github.run_id }}"
+          delete-branch: true

--- a/merge/md.json
+++ b/merge/md.json
@@ -2,36 +2,57 @@
     "nrf52dk": {
         "name": "Nordic nRF52 Development Kit",
         "method": "jlink-flash",
-        "jlink_device": "nRF52832_xxAA"
+        "jlink_device": "nRF52832_xxAA",
+        "workspace": "zephyr",
+        "board_target": "nrf52dk/nrf52832",
+        "artifact": "nrf52dk.elf"
     },
     "nrf52840dk": {
         "name": "Nordic nRF52840 Development Kit",
         "method": "jlink-flash",
-        "jlink_device": "nRF52840_xxAA"
+        "jlink_device": "nRF52840_xxAA",
+        "workspace": "zephyr",
+        "board_target": "nrf52840dk/nrf52840",
+        "artifact": "nrf52840dk.elf"
     },
     "nrf21540dk": {
         "name": "Nordic nRF21540 Development Kit",
         "method": "jlink-flash",
-        "jlink_device": "nRF52840_xxAA"
+        "jlink_device": "nRF52840_xxAA",
+        "workspace": "zephyr",
+        "board_target": "nrf21540dk/nrf52840",
+        "artifact": "nrf21540dk.elf"
     },
     "nrf54l15dk": {
         "name": "Nordic nRF54L15 Development Kit",
         "method": "jlink-flash",
-        "jlink_device": "nRF54L15_M33"
+        "jlink_device": "nRF54L15_M33",
+        "workspace": "zephyr",
+        "board_target": "nrf54l15dk/nrf54l15/cpuapp",
+        "artifact": "nrf54l15dk.elf"
     },
     "bg22_ek4108a": {
         "name": "Silicon Labs EFR32BG22 Explorer Kit (BG22-EK4108A)",
         "method": "jlink-flash",
-        "jlink_device": "EFR32BG22CXXXF512"
+        "jlink_device": "EFR32BG22CXXXF512",
+        "workspace": "zephyr",
+        "board_target": "bg22_ek4108a",
+        "artifact": "bg22_ek4108a.elf"
     },
     "lp_em_cc2340r5": {
         "name": "Texas Instrument LP-EM-2340R5 Development Kit",
         "method": "generate-hex",
-        "encryption": "AES-128-CTR"
+        "encryption": "AES-128-CTR",
+        "workspace": "ti-zephyr",
+        "board_target": "lp_em_cc2340r5",
+        "artifact": "lp_em_cc2340r5.elf"
     },
     "lp_em_cc2340r53": {
         "name": "Texas Instrument LP-EM-2340R53 Development Kit",
         "method": "generate-hex",
-        "encryption": "AES-128-CTR"
+        "encryption": "AES-128-CTR",
+        "workspace": "ti-zephyr",
+        "board_target": "lp_em_cc2340r53",
+        "artifact": "lp_em_cc2340r53.elf"
     }
 }


### PR DESCRIPTION
Adds a single workflow_dispatch workflow that builds every board across both firmware/zephyr and firmware/ti-zephyr in parallel and (with deploy=true) opens one PR updating merge/*.elf. The boards matrix is centralized in merge/md.json via new workspace, board_target, and artifact fields, so adding a board is a single-file change.

Both build jobs delegate west install/init/update, Zephyr SDK download and caching, ccache wiring, and Zephyr's pip deps to zephyrproject-rtos/action-zephyr-setup@v1. The TI build pins Python 3.11 and Zephyr SDK 0.16.9 per the libc-hooks.c gotcha; Nordic uses Python 3.12 and SDK 0.17.0. Both jobs run a verify step that mirrors elfmgr._find_symbol to guarantee master_key and utc_time remain patchable before publishing.