### PR TITLE
ci: add release workflow for pyhubbledemo PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+defaults:
+  run:
+    working-directory: python
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    outputs:
+      notes: ${{ steps.extract-notes.outputs.notes }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Verify tag matches package version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${REF_NAME#v}"
+          PKG_VERSION=$(python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(data['project']['version'])
+          ")
+          echo "Tag version:     ${TAG_VERSION}"
+          echo "Package version: ${PKG_VERSION}"
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "ERROR: git tag does not match pyproject.toml version"
+            exit 1
+          fi
+
+      - name: Lint
+        run: ruff check src
+
+      - name: Run unit tests (exclude integration, BLE, and Docker)
+        run: pytest -m "not integration and not ble and not docker" -v --tb=short
+
+      - name: Build sdist and wheel
+        run: |
+          pip install build
+          python -m build
+
+      - name: Read release notes
+        id: extract-notes
+        run: |
+          {
+            echo "notes<<EOF"
+            cat release-notes.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist
+          path: python/dist/
+          if-no-files-found: error
+
+  github-release:
+    needs: test-and-build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ needs.test-and-build.outputs.notes }}
+          files: dist/*
+          fail_on_unmatched_files: true
+
+  publish:
+    needs: github-release
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,57 @@
 # Hubble Demo Script
 
 This will enable you to flash a pre-determined set of boards and provision them with your credentials.
+
+## Releasing
+
+Releases are triggered by pushing a `vX.Y.Z` tag. The
+`.github/workflows/release.yml` workflow then runs lint + tests, builds
+sdist + wheel, creates a GitHub Release using `release-notes.md` as the
+body, and publishes to PyPI via OIDC trusted publishing.
+
+### One-time setup
+
+1. **PyPI Trusted Publisher** — at
+   <https://pypi.org/manage/project/pyhubbledemo/settings/publishing/>,
+   add a publisher with:
+   - Owner: `HubbleNetwork`
+   - Repository: `hubble-tldm`
+   - Workflow filename: `release.yml`
+   - Environment name: `pypi`
+2. **GitHub Environment** — in repo Settings → Environments, create an
+   environment named `pypi`. Optionally add a required-reviewer rule so
+   each publish needs manual approval.
+
+### Cutting a release
+
+Run all commands from the repo root.
+
+1. **Bump the version** in `python/pyproject.toml` (`project.version`).
+   The git tag must exactly match this string with a `v` prefix.
+2. **Update `python/release-notes.md`** — prepend a new section under
+   `# Release Notes`:
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+
+   ### Added
+   - feat(...): ...
+
+   ### Fixed
+   - fix(...): ...
+   ```
+   The full file is dumped as the GitHub Release body, so keep it
+   readable.
+3. **Commit and tag**:
+   ```bash
+   git add python/pyproject.toml python/release-notes.md
+   git commit -m "chore: release X.Y.Z"
+   git tag vX.Y.Z
+   git push origin master
+   git push origin vX.Y.Z
+   ```
+4. **Approve the publish step** — if you enabled the reviewer gate on
+   the `pypi` environment, the workflow will pause before pushing to
+   PyPI until you approve it in the Actions UI.
+
+Watch progress at
+<https://github.com/HubbleNetwork/hubble-tldm/actions>.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,4 +40,22 @@ include = [
   "README.md",
   "LICENSE",
   "pyproject.toml",
+  "tests",
+]
+
+# ---- Testing & dev tooling ----
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+markers = [
+  "ble: tests that require BLE hardware/permissions",
+  "docker: tests that require a running Docker daemon",
+  "integration: slow or environment-dependent tests",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7",
+  "pytest-cov",
+  "ruff",
 ]

--- a/python/release-notes.md
+++ b/python/release-notes.md
@@ -1,0 +1,1 @@
+# Release Notes

--- a/python/src/hubbledemo/elfmgr.py
+++ b/python/src/hubbledemo/elfmgr.py
@@ -4,7 +4,6 @@ from hubblenetwork import Device
 
 import io
 import os
-import base64
 import tempfile
 import pylink
 from elftools.elf.elffile import ELFFile

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -1,0 +1,13 @@
+def test_package_imports():
+    import hubbledemo
+
+    assert hubbledemo.flash_elf
+    assert hubbledemo.patch_elf
+    assert hubbledemo.fetch_elf
+    assert hubbledemo.fetch_metadata
+
+
+def test_cli_imports():
+    from hubbledemo import cli
+
+    assert cli.main


### PR DESCRIPTION
Tag-triggered (vX.Y.Z) workflow that verifies the tag matches the package version, lints, runs unit tests, builds sdist+wheel, creates a GitHub Release, and publishes to PyPI via OIDC trusted publishing.

Supporting changes:
- pyproject.toml: add [dev] extra (ruff, pytest, pytest-cov) and pytest config (testpaths, pythonpath, ble/docker/integration markers)
- tests/test_smoke.py: import-smoke tests so pytest has something to run and packaging breakage gets caught
- release-notes.md: seed the changelog file the workflow reads as the GitHub Release body
- elfmgr.py: drop unused base64 import (would fail ruff lint)
- README.md: document the one-time PyPI/environment setup and the manual release steps