### PR TITLE
bug: print device key as base64 instead of bytes repr

### DIFF
--- a/python/src/hubbledemo/cli.py
+++ b/python/src/hubbledemo/cli.py
@@ -115,7 +115,7 @@ def flash(board: str, name: str = None, file: str = None, org_id: str = None, to
         device = org.register_device(encryption=metadata[board]["encryption"] if "encryption" in metadata[board] else None)
         click.secho("[SUCCESS]")
         click.secho(f"\tDevice ID:  {device.id}")
-        click.secho(f"\tDevice Key: {device.key}")
+        click.secho(f"\tDevice Key: {base64.b64encode(device.key).decode('ascii')}")
 
         # Generate device name if not provided
         if not name:


### PR DESCRIPTION
The flash command printed device.key as a Python bytes literal (e.g. b'\x06i...'), which users could not paste into HUBBLE_DEVICE_KEY. Base64-encode the key so the printed value matches the format expected when re-using it.