### PR TITLE
Add support for the lp_em_cc2755p10 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ pipx run pyhubbledemo flash <BOARD> -o <ORG_ID> -t <API_TOKEN>
 Currently supported boards:
 * nrf52dk
 * nrf52840dk
+* lp_em_cc2755p10

--- a/firmware/ti-zephyr/hubble-demo-app/west.yml
+++ b/firmware/ti-zephyr/hubble-demo-app/west.yml
@@ -13,7 +13,7 @@ manifest:
   projects:
     - name: simplelink-zephyr
       remote: simplelink-zephyr
-      revision: v3.7.0-ti-9.14.00_ea
+      revision: v3.7.0-ti-9.14
       path: zephyr
       import: true
       west-commands: scripts/west-commands.yml

--- a/merge/md.json
+++ b/merge/md.json
@@ -54,5 +54,13 @@
         "workspace": "ti-zephyr",
         "board_target": "lp_em_cc2340r53",
         "artifact": "lp_em_cc2340r53.elf"
+    },
+    "lp_em_cc2755p10": {
+        "name": "Texas Instruments CC2755P10 LaunchPad",
+        "method": "generate-hex",
+        "encryption": "AES-128-CTR",
+        "workspace": "ti-zephyr",
+        "board_target": "lp_em_cc2755p10",
+        "artifact": "lp_em_cc2755p10.elf"
     }
 }

--- a/python/README.md
+++ b/python/README.md
@@ -30,7 +30,7 @@ pytest -s -m integration tests/test_e2e.py -v
 ```
 
 `-s` is required because TI `generate-hex` boards (`lp_em_cc2340r5`,
-`lp_em_cc2340r53`) emit a `.hex` and the test pauses to ask you to flash
+`lp_em_cc2340r53`, `lp_em_cc2755p10`) emit a `.hex` and the test pauses to ask you to flash
 it manually before continuing.
 
 #### Testing a locally-built ELF


### PR DESCRIPTION
## Summary

Registers the TI CC2755P10 LaunchPad (`lp_em_cc2755p10`) as a supported `generate-hex` board in `pyhubbledemo`. Config + docs only — the firmware artifact is produced by CI, not committed here (see below).

- **`merge/md.json`** — new `lp_em_cc2755p10` entry using the `generate-hex` method with `AES-128-CTR` (same as the existing cc2340 TI boards).
- **`firmware/ti-zephyr/hubble-demo-app/west.yml`** — TI fork revision bump `v3.7.0-ti-9.14.00_ea` → `v3.7.0-ti-9.14`, which introduces the cc2755p10 board definition.
- **Docs** — added the board to the README "Supported Boards" list and the TI `generate-hex` board list in `python/README.md`.

## The ELF artifact is intentionally not in this PR

`merge/*.elf` is built reproducibly in CI (`build-firmware.yml`, pinned Zephyr SDK 0.16.9) and committed via the deploy workflow — not by hand. On this PR, CI will build the new board and run `verify-firmware-elf.py` against it as a check. After merge, run `build-firmware.yml` via `workflow_dispatch` with `deploy: true` to open the automated `chore(merge): rebuild firmware ELFs` PR that commits `merge/lp_em_cc2755p10.elf`.

The board will not be flashable via `hubbledemo flash lp_em_cc2755p10` until that deploy PR merges.

## Notes

- The board definition already existed in the TI fork at the new revision; this PR is the integration.
- Existing cc2340 / cc2340r53 ELFs in `merge/` predate the new fork revision and are intentionally not rebuilt here.

## Test Plan

- [ ] CI `build-firmware` builds `lp_em_cc2755p10` and `verify-firmware-elf.py` passes (validates the `master_key` patching contract).
- [x] `merge/md.json` is valid JSON; `artifact` filename matches the planned ELF name.
- [x] Non-integration test suite passes (`pytest -m "not integration"`).
- [ ] After merge + deploy workflow: hardware smoke test — flash the generated `.hex` to a physical CC2755P10 LaunchPad and confirm provisioning / advertising.