### PR TITLE
fix(firmware): pin Nordic Zephyr manifest to v4.4.0 release

### DIFF
--- a/firmware/zephyr/hubble-demo-app/west.yml
+++ b/firmware/zephyr/hubble-demo-app/west.yml
@@ -12,7 +12,12 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      # Pin to a tagged release instead of tracking `main`. Tracking `main`
+      # drifted onto an upstream tree where Kconfig warnings are fatal
+      # (UART_CONSOLE vs. disabled uart0, and PSA_WANT_* crypto deps from the
+      # SDK), breaking the Nordic build. Mirrors the TI workspace, which also
+      # pins. Bump deliberately rather than letting `main` move under us.
+      revision: v4.4.0
       import: true
       west-commands: scripts/west-commands.yml
     - name: hubblenetwork-sdk


### PR DESCRIPTION
## Problem

The `build-firmware` CI was failing for **all Nordic boards** (`nrf52dk`, `nrf52840dk`, `nrf21540dk`, `nrf54l15dk`) at the Kconfig stage:

```
error: Aborting due to Kconfig warnings
```

driven by two unsatisfied-dependency warnings (upstream now treats them as fatal):

1. **Serial/console** — the nRF board `_defconfig` sets `CONFIG_UART_CONSOLE=y`, but `app/boards/*.overlay` disables `uart0`, so `SERIAL_HAS_DRIVER=n` and `UART_CONSOLE` can't be `y`.
2. **PSA crypto** — the SDK's default backend `HUBBLE_NETWORK_CRYPTO_PSA` does `select PSA_WANT_ALG_CMAC / PSA_WANT_ALG_CTR / PSA_WANT_KEY_TYPE_AES`, whose newer upstream mbedtls dependencies are no longer satisfied.

## Root cause

`firmware/zephyr/hubble-demo-app/west.yml` pinned the upstream Zephyr project to `revision: main` — a **floating** pointer. Since the last good build, `main` advanced and that drift made the two Kconfig conditions fatal. Both source conditions predate the breakage; only the upstream churn is new. The TI workspace already pins a fixed revision; the Nordic workspace was the outlier tracking `main`.

## Fix

Pin the Nordic Zephyr revision to the **`v4.4.0` release tag** instead of a floating branch, mirroring the TI workspace. A tagged release is preferable to a bare commit SHA. Going forward, bump deliberately rather than letting `main` move under us.

## Verification

`build-firmware` CI green across the full matrix on this branch ([run 26264349969](https://github.com/HubbleNetwork/hubble-tldm/actions/runs/26264349969)):

- nRF: `nrf52dk`, `nrf52840dk`, `nrf21540dk`, `nrf54l15dk` ✅
- SiLabs: `bg22_ek4108a` ✅
- TI: `lp_em_cc2340r5`, `lp_em_cc2340r53` ✅

## Follow-ups (non-blocking)

- The red CI on #22 (cc2755p10 board) was caused by this same Nordic drift; rebase/re-run #22 once this merges.
- `v4.4.0` is older than the tree the currently-shipping `merge/*.elf` were built from — when the Nordic ELFs are next rebuilt via the deploy workflow, they'll be `v4.4.0`-based. Consider bumping to a newer 4.4.x point release if/when one is published.